### PR TITLE
#20 fix smtp messages

### DIFF
--- a/examples/client_example.nim
+++ b/examples/client_example.nim
@@ -13,8 +13,12 @@ proc `[]`(c: Config, key: string): string = c.getSectionValue("", key)
 
 let
   conf = loadConfig("smtp.ini")
-  msg = createMessage("Hello from Nim's SMTP!",
-    "Hello!\n Is this awesome or what?", @[conf["recipient"]])
+  msg = createMessage(
+    "Hello from Nim's SMTP!",
+    "Hello!\n Is this awesome or what?", 
+    conf["sender"],
+    @[conf["recipient"]]
+  )
 
 assert conf["smtphost"] != ""
 
@@ -26,6 +30,7 @@ proc async_test() {.async.} =
   await client.connect(conf["smtphost"], conf["port"].parseInt.Port)
   await client.auth(conf["username"], conf["password"])
   await client.sendMail(conf["sender"], @[conf["recipient"]], $msg)
+  await client.sendMail(msg)
   await client.close()
   echo "async email sent"
 
@@ -37,6 +42,7 @@ proc sync_test() =
   smtpConn.connect(conf["smtphost"], conf["port"].parseInt.Port)
   smtpConn.auth(conf["username"], conf["password"])
   smtpConn.sendMail(conf["sender"], @[conf["recipient"]], $msg)
+  smtpConn.sendMail(msg)
   smtpConn.close()
   echo "sync email sent"
 

--- a/src/smtp.nim
+++ b/src/smtp.nim
@@ -242,9 +242,7 @@ proc newSmtp*(useSsl = false, debug = false, sslContext: SslContext = nil): Smtp
     else:
       raise newException(AssertionDefect, "SMTP module compiled without SSL support")
 
-proc newAsyncSmtp*(
-    useSsl = false, debug = false, sslContext: SslContext = nil
-): AsyncSmtp =
+proc newAsyncSmtp*(useSsl = false, debug = false, sslContext: SslContext = nil): AsyncSmtp =
   ## Creates a new `AsyncSmtp` instance.
   new result
   result.debug = debug

--- a/src/smtp.nim
+++ b/src/smtp.nim
@@ -73,9 +73,12 @@ type
 
 const NEW_LINE = "\c\L"
 
+proc containsNewline(str: string): bool =
+  str.contains({'\c', '\L'})
+
 proc containsNewline(xs: seq[string]): bool =
   for x in xs:
-    if x.contains({'\c', '\L'}):
+    if x.containsNewline():
       return true
 
 proc debugSend*(smtp: Smtp | AsyncSmtp, cmd: string) {.multisync.} =
@@ -297,8 +300,10 @@ proc sendMail*(smtp: Smtp | AsyncSmtp, fromAddr: string,
   ##
   ## You need to make sure that `fromAddr` and `toAddrs` don't contain
   ## any newline characters. Failing to do so will raise `AssertionDefect`.
-  doAssert(not (toAddrs.containsNewline() or fromAddr.contains({'\c', '\L'})),
-           "'toAddrs' and 'fromAddr' shouldn't contain any newline characters")
+  doAssert(
+    not (toAddrs.containsNewline() or fromAddr.containsNewline()),
+    "'toAddrs' and 'fromAddr' shouldn't contain any newline characters"
+  )
 
   await smtp.debugSend(fmt"""MAIL FROM:<{fromAddr}>{NEW_LINE}""")
   await smtp.checkReply("250")

--- a/src/smtp.nim
+++ b/src/smtp.nim
@@ -365,6 +365,19 @@ proc sendMail*(
   await smtp.debugSend("." & NEW_LINE)
   await smtp.checkReply("250")
 
+proc sendMail*(smtp: Smtp | AsyncSmtp, msg: Message) {.multisync.} =
+  ## Convenience utility for sending messages.
+  ## Sends `msg` from the sender as specified in `sender <#sender,Message>`_
+  ## and the recipients as specified in `recipients <#recipients,Message>`_.
+  ## 
+  ## See also:
+  ## * `sendMail <#sendMail,Smtp,string,seq[string],string>`_
+  let senderAddress = msg.sender().address
+  let recipientAddresses = msg.recipients().mapIt(it.address)
+  let msgBody = $msg
+  echo "SENDING: ", msgBody
+  await smtp.sendMail(senderAddress, recipientAddresses, msgBody)
+
 proc close*(smtp: Smtp | AsyncSmtp) {.multisync.} =
   ## Disconnects from the SMTP server and closes the socket.
   await smtp.debugSend("QUIT\c\L")

--- a/src/smtp.nim
+++ b/src/smtp.nim
@@ -137,14 +137,14 @@ proc createMessage*[T: Email | string](
 
   let senderMail = sender.toEmail()
 
-  result.msgSubject = mSubject
-  result.msgBody = mBody
-  result.msgTo = mTo.mapIt(toEmail(it))
-  result.msgCc = mCc.mapIt(toEmail(it))
-  result.msgBcc = mBcc.mapIt(toEmail(it))
-  result.msgReplyTo = mReplyTo.mapIt(toEmail(it))
-  result.msgSender = senderMail
-  result.msgOtherHeaders = newStringTable()
+  result = Message(msgSubject: mSubject,
+    msgBody: mBody,
+    msgTo: mTo.mapIt(toEmail(it)),
+    msgCc: mCc.mapIt(toEmail(it)),
+    msgBcc: mBcc.mapIt(toEmail(it)),
+    msgReplyTo: mReplyTo.mapIt(toEmail(it)),
+    msgSender: senderMail,
+    msgOtherHeaders: newStringTable())
   for n, v in items(otherHeaders):
     result.msgOtherHeaders[n] = v
 


### PR DESCRIPTION
Small overhaul over the Message aspect of smtp.

Currently it does not work (at least during my testing with my email provider for my website) as the "From"-header is never set. 

This is fixed here.

However, further, Email is not being fully represented, as it can also be written as "name" <email>, which requires an Email to be an object where you can add a name (optionally) and which gets stringified in one of 2 ways depending on whether name was set or not.

This was also added.

Further, for convenience purposes, an overload of sendMail was added that uses message entirely to infer sender, recipient and body, rather than just creating a body from it.

Further, another, seemingly pointless, overload of sendMail was removed.

This is all of course merely a suggestion. What I mostly want out of this to be applied is the addition of "from: " during stringification, as this legitimately breaks smtp for me. The other aspects are just things I did because they seem like improvements to me.